### PR TITLE
Checkout only relevant files

### DIFF
--- a/features/bundler_auto_update.feature
+++ b/features/bundler_auto_update.feature
@@ -41,6 +41,7 @@ Feature: Auto update Gemfile
       """
         - Test suite failed to run.
         - Reverting changes
+          > git status | grep 'Gemfile.lock' > /dev/null
           > git checkout Gemfile Gemfile.lock
       """
 

--- a/lib/bundler_auto_update.rb
+++ b/lib/bundler_auto_update.rb
@@ -119,12 +119,15 @@ module Bundler
       def commit_new_version
         Logger.log_indent "Committing changes"
 
-        files_to_commit = if CommandRunner.system "git status | grep 'Gemfile.lock' > /dev/null"
-                            "Gemfile Gemfile.lock"
-                          else
-                            "Gemfile"
-                          end
         CommandRunner.system "git commit #{files_to_commit} -m 'Auto update #{gem.name} to version #{gem.version}'"
+      end
+
+      def files_to_commit
+        @files_to_commit ||= if CommandRunner.system "git status | grep 'Gemfile.lock' > /dev/null"
+                               "Gemfile Gemfile.lock"
+                             else
+                               "Gemfile"
+                             end
       end
 
       def revert_to_previous_version

--- a/lib/bundler_auto_update.rb
+++ b/lib/bundler_auto_update.rb
@@ -132,7 +132,7 @@ module Bundler
 
       def revert_to_previous_version
         Logger.log_indent "Reverting changes"
-        CommandRunner.system "git checkout Gemfile Gemfile.lock"
+        CommandRunner.system "git checkout #{files_to_commit}"
         gemfile.reload!
       end
     end # class GemUpdater

--- a/spec/unit/gem_updater_spec.rb
+++ b/spec/unit/gem_updater_spec.rb
@@ -78,6 +78,20 @@ describe GemUpdater do
 
           expect(gem_updater.update(:patch)).to eq(false)
         end
+
+      end
+
+      context "when it fails to upgrade gem and only Gemfile is checked in" do
+        it 'should revert only Gemfile' do
+          expect(gem).to receive(:last_version).with(:patch) { gem.version.next }
+          expect(gem_updater).to receive(:update_gemfile).and_return false
+          expect(CommandRunner).to receive(:system).
+            with("git status | grep 'Gemfile.lock' > /dev/null").and_return false
+          expect(CommandRunner).to receive(:system).
+            with("git checkout Gemfile").and_return false
+
+          gem_updater.update(:patch)
+        end
       end
     end
   end # describe "#update"


### PR DESCRIPTION
This change avoids a warning from git about `Gemfile.lock` not being checked in when restoring the original files with `git checkout`.
